### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,7 @@ will produce
 ## Disclaimer
 
 Long trees don't always display correctly.
+
+## Environments
+- Bash: OK
+- Zsh: Not OK (Run `exec bash` to switch from Zsh to Bash if you are using Mac terminal).


### PR DESCRIPTION
Zsh cannot run treevis properly, it will show error message:
```
zsh: no matches found: [5,4,7,3,null,2,null,-1,null,9]
```
Enhance the readme for letting people know how to switch from Zsh to Bash if using terminal in Mac.